### PR TITLE
Add license to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "cmpa"
 version = "0.1.0"
 edition = "2021"
 
+license = "Apache-2.0"
 license-file = "LICENSE"
 description = "Multiprecision arithmetic primitives commonly needed for asymmetric cryptography"
 homepage = "https://github.com/nicstange/cmpa-rs"


### PR DESCRIPTION
Cargo.toml is missing the `license` field. This results in an incorrect detection of the project's license on crates.io.